### PR TITLE
feat: Re-export lit

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,9 @@
 import { LitElement } from "lit";
 import { registerTranslateConfig, get } from "lit-translate";
 
+// Re-export lit 
+export * from "lit";
+
 export class PodiumElement extends LitElement {
   #translationSupport = false;
 


### PR DESCRIPTION
This re-exports Lit. With this one does not need to add Lit as a dependency to use Lit.

Instead of this;

```js
import { html, css } from "lit";
import { PodiumElement } from "@podium/element";
```

one can now just do this:

```js
import { PodiumElement, html, css } from "@podium/element";
```